### PR TITLE
`setup` rake tasks sets up seeds and also creates user [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cp config/database.yml.postgresql config/database.yml
 brew install elasticsearch
 brew services start elasticsearch
 
-./bin/rails db:setup
+./bin/rails setup
 
 ./bin/yarn install
 


### PR DESCRIPTION
- so better to use it instead of just db:setup which does not create user