### PR TITLE
GraphQL API:Adding user to organization

### DIFF
--- a/app/graphql/mutations/assign_user_to_organization_mutations.rb
+++ b/app/graphql/mutations/assign_user_to_organization_mutations.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Mutations::AssignUserToOrganizationMutations
+  Assign = GraphQL::Relay::Mutation.define do
+    name "AssignUserToOrganization"
+
+    input_field :email, !types.String
+    input_field :name, types.String
+
+    return_field :user, Types::UserType
+    return_field :errors, types[Types::ErrorType]
+
+    resolve -> (object, inputs, context) {
+      # TODO, add no-org error handler when #304 merge Issue#https://github.com/bigbinary/acehelp/issues/324
+      user = User.find_or_create_by(email: inputs[:email]) do |user|
+        user.name = inputs[:name] || user.extract_firstname_from_email
+        user.password = user.password_confirmation =  Devise.friendly_token.first(8)
+      end
+
+      if user.blank?
+        errors = Utils::ErrorHandler.new.detailed_error(user, context)
+      else
+        user.assign_organization(context[:organization])
+      end
+
+      {
+        user: user,
+        errors: errors
+      }
+    }
+  end
+end

--- a/app/graphql/mutations/assign_user_to_organization_mutations.rb
+++ b/app/graphql/mutations/assign_user_to_organization_mutations.rb
@@ -11,18 +11,16 @@ class Mutations::AssignUserToOrganizationMutations
     return_field :errors, types[Types::ErrorType]
 
     resolve -> (object, inputs, context) {
-      # TODO, add no-org error handler when #304 merge Issue#https://github.com/bigbinary/acehelp/issues/324
       user = User.find_or_create_by(email: inputs[:email]) do |user|
-        user.name = inputs[:name] || user.extract_firstname_from_email
+        user.name = inputs[:name]
         user.password = user.password_confirmation =  Devise.friendly_token.first(8)
       end
 
       if user.blank?
-        errors = Utils::ErrorHandler.new.detailed_error(user, context)
+        errors = Utils::ErrorHandler.new.error("User not found/created", context)
       else
         user.assign_organization(context[:organization])
       end
-
       {
         user: user,
         errors: errors

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -39,4 +39,6 @@ Types::MutationType = GraphQL::ObjectType.define do
   field :loginUser, field: Mutations::LoginMutations::Login.field
   field :forgotPassword, field: Mutations::ForgotPasswordMutations::Perform.field
 
+  field :assign_user_to_organization, field: Mutations::AssignUserToOrganizationMutations::Assign.field
+
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -8,6 +8,7 @@ Types::UserType = GraphQL::ObjectType.define do
   field :first_name, !types.String
   field :last_name, types.String
   field :role, types.String
+  field :organization_id, types.String
 
   field :name, -> { !types.String } do
     resolve -> (obj, args, context) { obj.name }

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -5,12 +5,12 @@ Types::UserType = GraphQL::ObjectType.define do
 
   field :id, !types.String
   field :email, !types.String
-  field :first_name, !types.String
+  field :first_name, types.String
   field :last_name, types.String
   field :role, types.String
   field :organization_id, types.String
 
-  field :name, -> { !types.String } do
+  field :name, -> { types.String } do
     resolve -> (obj, args, context) { obj.name }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,27 @@ class User < ApplicationRecord
     "#{first_name} #{last_name}".squish
   end
 
+  def name=(name)
+    user = self
+    user.first_name, user.last_name = name.split(/\s+/, 2)
+  end
+
+  def extract_firstname_from_email
+    email.split('@').first
+  end
+
   def add_organization(args)
     user = self
     user.organization = Organization.new(email: args["email"], name: args["name"])
     user.save
     user.organization
   end
+
+  def assign_organization(org_data)
+    user = self
+    org_data = org_data.id if org_data.is_a?(Organization)
+    user.organization_id = org_data
+    user.save
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,25 +8,20 @@ class User < ApplicationRecord
 
   acts_as_token_authenticatable
 
-  validates :first_name, presence: true
-
   belongs_to :organization, autosave: true, dependent: :destroy, required: false
 
   has_many :organization_users, dependent: :destroy
   has_many :organizations, through: :organization_users
 
   def name
-    "#{first_name} #{last_name}".squish
+    ("#{first_name} #{last_name}".squish).presence || "Anonymous"
   end
 
   def name=(name)
     user = self
-    user.first_name, user.last_name = name.split(/\s+/, 2)
+    user.first_name, user.last_name = name.split(/\s+/, 2) if name
   end
 
-  def extract_firstname_from_email
-    email.split('@').first
-  end
 
   def add_organization(args)
     user = self

--- a/test/graphql/mutations/assign_user_to_organization_mutations_test.rb
+++ b/test/graphql/mutations/assign_user_to_organization_mutations_test.rb
@@ -39,7 +39,7 @@ class Mutations::AssignUserToOrganizationMutationsTest < ActiveSupport::TestCase
   end
 
   test "api should return new user" do
-    new_email = "new_email@example.com"
+    new_email = "new_email+#{rand(1000)}@example.com"
     result =  AceHelp::Client.execute(@query, user_keys: { email: new_email })
     assert_equal new_email,  result.data.assign_user_to_organization.user.email
   end

--- a/test/graphql/mutations/assign_user_to_organization_mutations_test.rb
+++ b/test/graphql/mutations/assign_user_to_organization_mutations_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "graphql/client_host"
+
+class Mutations::AssignUserToOrganizationMutationsTest < ActiveSupport::TestCase
+
+  setup do
+    @ethan = users(:hunt)
+
+    @query = <<-GRAPHQL
+        mutation($user_keys: AssignUserToOrganizationInput!) {
+            assign_user_to_organization(input: $user_keys) {
+              user {
+                id
+                email
+                first_name
+                last_name
+                organization_id
+              }
+              errors {
+                message
+                path
+              }
+            }
+        }
+    GRAPHQL
+  end
+
+
+  test "assign organization" do
+    result =  AceHelp::Client.execute(@query, user_keys: { email: @ethan.email})
+    assert_equal organizations(:bigbinary).id,  result.data.assign_user_to_organization.user.organization_id
+  end
+
+  test "api should return correct user" do
+    result =  AceHelp::Client.execute(@query, user_keys: { email: @ethan.email})
+    assert_equal @ethan.email,  result.data.assign_user_to_organization.user.email
+  end
+
+  test "api should return new user" do
+    new_email = "new_email@example.com"
+    result =  AceHelp::Client.execute(@query, user_keys: { email: new_email })
+    assert_equal new_email,  result.data.assign_user_to_organization.user.email
+  end
+
+  test "assign organization with name" do
+    new_email_2 =
+    result =  AceHelp::Client.execute(@query, user_keys: { email: "new_email_2@example.com", name: "Sagar Alias Jackey" })
+    assert_equal "Sagar",  result.data.assign_user_to_organization.user.first_name
+    assert_equal "Alias Jackey",  result.data.assign_user_to_organization.user.last_name
+  end
+end

--- a/test/graphql/mutations/forgot_password_mutations_test.rb
+++ b/test/graphql/mutations/forgot_password_mutations_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 require "graphql/client_host"
 
-class Mutations::LoginMutationsTest < ActiveSupport::TestCase
+class Mutations::ForgotPasswordMutationsTest < ActiveSupport::TestCase
 
   setup do
     @ethan = users(:hunt)


### PR DESCRIPTION
GraphQL endpoint to add a new user to the organization.
accepts : email (required), name(optional).
If a user with given email already exists then add that user to the org.
If a user with that email does not exist then create a user with that email and then add that user to the org.