### PR TITLE
 #517 Use our forked version of devise_token_auth gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rails", "~> 5.2.1"
 gem "devise", "~> 4.4.0"
 
 # Use this gem to support token-authentication with devise
-gem 'devise_token_auth'
+gem 'devise_token_auth', github: 'BigBinary/devise_token_auth'
 
 # Use pg as the database for Active Record
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/BigBinary/devise_token_auth.git
+  revision: 5987cc6fb0970f0d426d931116fcabed83a3a58b
+  specs:
+    devise_token_auth (1.0.0.rc1)
+      devise (> 3.5.2, < 4.6)
+      rails (< 6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -89,9 +97,6 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
-    devise_token_auth (0.1.43)
-      devise (> 3.5.2, < 4.5)
-      rails (< 6)
     docile (1.3.1)
     elasticsearch (6.1.0)
       elasticsearch-api (= 6.1.0)
@@ -306,7 +311,7 @@ DEPENDENCIES
   delayed_job_active_record
   delayed_job_recurring
   devise (~> 4.4.0)
-  devise_token_auth
+  devise_token_auth!
   graphlient (~> 0.3.2)
   graphql
   graphql-preload


### PR DESCRIPTION
- This uses the fix from https://github.com/bigbinary/devise_token_auth/commit/5987cc6fb0970f0d426d931116fcabed83a3a58b