### PR TITLE
prevent data reset after every deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -C config/puma.rb
-release: bundle exec rake db:migrate && bundle exec rake perform_on_every_deploy
+release: bundle exec rake db:migrate


### PR DESCRIPTION
This change is necessary to keep API-Key constant after every deployment.