### PR TITLE
Do not ignore check for CVE-2016-10545 since it is not a security issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
       - run: chmod +x node_modules/.bin/elm
 
       - run: bin/webpack
-      - run: bundle exec ruby-audit check --ignore CVE-2016-10545
+      - run: bundle exec ruby-audit check
       - run: bundle exec bundle-audit check --update
 
       # Unit tests


### PR DESCRIPTION
The CVE with ID CVE-2016-10545 has been rejected.
According to https://nvd.nist.gov/vuln/detail/CVE-2016-10545, investigation showed that it was not a security issue.

Fixes https://github.com/bigbinary/acehelp/issues/707.