### PR TITLE
Added command to start redis-server for worker

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
 web: bundle exec rails s -p 3000
 webpacker: ./bin/webpack-dev-server
-worker: bundle exec sidekiq -C config/sidekiq.yml
+worker: redis-server && bundle exec sidekiq -C config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec rails s -p 3000
 webpacker: ./bin/webpack-dev-server
-worker: redis-server && bundle exec sidekiq -C config/sidekiq.yml
+redis: redis-server
+worker: bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
I updated master and was trying to run `foreman start -f Procfile.dev`, but it was showing errors.
I saw that we had moved from delayed job to sidekiq and the error was because it could not connect to redis.

Instead of having to run `redis-server` to start redis in another terminal tab, should we include it in the procfile?

@neerajdotname @tejaswinichile @ritesh404 @vishaltelangre  thoughts?
